### PR TITLE
fix: isolate puppet rendering to prevent background bleed-through (#4)

### DIFF
--- a/lib/src/render/canvas_renderer.dart
+++ b/lib/src/render/canvas_renderer.dart
@@ -47,9 +47,18 @@ class CanvasRenderer {
     final viewProjection = camera.viewProjectionMatrix(size.width, size.height);
     _applyMatrix(canvas, viewProjection, size);
 
+    // Isolate puppet rendering in a transparent compositing layer.
+    // Without this, drawables with multiply (or other) blend modes that
+    // are not inside a Composite node blend directly against the canvas
+    // background (e.g. gray), producing incorrect colors (Issue #4).
+    // Inside this layer, blend modes only interact with previously drawn
+    // puppet content, matching PSD compositing behavior.
+    canvas.saveLayer(null, Paint());
+
     // Draw all drawables
     _drawAllDrawables(canvas, puppet);
 
+    canvas.restore(); // compositing layer
     canvas.restore();
   }
 


### PR DESCRIPTION
## Summary
- Wraps all drawable rendering in a transparent `saveLayer` so blend modes (especially multiply) only interact with previously drawn puppet content, not the canvas background
- Prevents gray background from bleeding through semi-transparent multiply layers (e.g. cheek blush)
- Matches PSD compositing behavior

## Changes
- `lib/src/render/canvas_renderer.dart`: Added `canvas.saveLayer(null, Paint())` around `_drawAllDrawables()` in `render()`

## Test plan
- [x] Built utsutsu-builder with the fix
- [x] Loaded tsukuyomi model and compared face/cheek rendering before and after
- [x] After fix: blush is cleaner pink, matching the PSD reference
- [x] Before fix: blush had subtle gray contamination from background bleed-through
- [x] Verified no regression in overall rendering (hair, clothing, skin)

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)