### PR TITLE
fix: account for device pixel ratio in PSD compositor

### DIFF
--- a/lib/src/widgets/puppet_widget.dart
+++ b/lib/src/widgets/puppet_widget.dart
@@ -484,11 +484,13 @@ class _PuppetWidgetState extends State<PuppetWidget>
       );
     }
 
+    final dpr = MediaQuery.devicePixelRatioOf(context);
     return CustomPaint(
       painter: _PuppetPainter(
         renderer: renderer,
         puppet: puppet,
         repaint: widget.controller,
+        devicePixelRatio: dpr,
       ),
       size: Size.infinite,
     );
@@ -525,22 +527,25 @@ class _PuppetWidgetState extends State<PuppetWidget>
 class _PuppetPainter extends CustomPainter {
   final CanvasRenderer renderer;
   final Puppet puppet;
+  final double devicePixelRatio;
 
   _PuppetPainter({
     required this.renderer,
     required this.puppet,
     Listenable? repaint,
+    this.devicePixelRatio = 1.0,
   }) : super(repaint: repaint);
 
   @override
   void paint(Canvas canvas, Size size) {
+    renderer.devicePixelRatio = devicePixelRatio;
     renderer.render(canvas, size, puppet);
   }
 
   @override
   bool shouldRepaint(_PuppetPainter oldDelegate) {
-    // rendererまたはpuppetのインスタンスが変わった場合のみ再描画
-    // アニメーションフレームの更新は、repaint Listenableによって処理される
-    return renderer != oldDelegate.renderer || puppet != oldDelegate.puppet;
+    return renderer != oldDelegate.renderer ||
+        puppet != oldDelegate.puppet ||
+        devicePixelRatio != oldDelegate.devicePixelRatio;
   }
 }


### PR DESCRIPTION
## Summary

- PSD compositor の `toImageSync()` が論理ピクセルサイズでオフスクリーンバッファを生成していたため、Retina ディスプレイ (DPR=2) で描画がガビガビになっていた
- `CanvasRenderer.devicePixelRatio` フィールドを追加し、オフスクリーンバッファを `logical × DPR` のピクセルサイズで生成するよう修正
- `PuppetWidget` が `MediaQuery.devicePixelRatioOf(context)` から自動で DPR を設定

## Changes

- `CanvasRenderer`: `devicePixelRatio` field (default 1.0)
- `_renderWithPsdCompositor`: buffer size `pw = size.width * dpr`, internal canvas `scale(dpr)`, final draw `scale(1/dpr)`
- `_renderMeshContentToImage`: same DPR scaling
- `_PuppetPainter`: accepts and applies `devicePixelRatio`

## Test plan

- [x] utsutsu-code (macOS Retina 2x) でビルド・起動し、PSD compositor 有効のまま描画がクリアなことを確認
- [ ] 非 Retina ディスプレイ (DPR=1) で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)